### PR TITLE
Use TryGetValues in RateLimitExtension to prevent Exception

### DIFF
--- a/RingCentral.Net.RateLimit/RateLimitExtension.cs
+++ b/RingCentral.Net.RateLimit/RateLimitExtension.cs
@@ -21,12 +21,14 @@ namespace RingCentral.Net.RateLimit
                     retriesAttempted < options.maxRetries,
                 retryInterval = (restException, retriesAttempted) =>
                 {
-                    var rateLimitWindowHeader = restException.httpResponseMessage.Headers
-                        .GetValues("x-rate-limit-window")
-                        .FirstOrDefault();
-                    if (rateLimitWindowHeader != default) options.rateLimitWindow = int.Parse(rateLimitWindowHeader);
-
-                    return (int) (options.rateLimitWindow * 1000 *
+                    string rateLimitWindowHeader = default;
+                    if (restException.httpResponseMessage.Headers
+                        .TryGetValues("x-rate-limit-window", out var values))
+                    {
+                        rateLimitWindowHeader = values.FirstOrDefault();
+                    }
+                    int rateLimitWindow = rateLimitWindowHeader == default ? options.rateLimitWindow : int.Parse(rateLimitWindowHeader);
+                    return (int) (rateLimitWindow * 1000 *
                                   Math.Pow(2, retriesAttempted)); // exponential back off
                 }
             };


### PR DESCRIPTION
Occasionally the API will respond with a 429 with no rate limit headers.

In this case the RateLimitExtension gets an error because it expects the X-RateLimit-Window header to be present.

This commit changes RateLimitExtension to use TryGetValues instead of GetValues since the header may not exist in the response.

resolves #53 